### PR TITLE
update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ and save it in your $HOME directory, then edit your .bashrc/.zshrc file with:
 `.zshrc` file:
 
 ```sh
-function kubectl() { echo "+ kubectl $@"; command kubectl $@; }
+function kubectl() { [[ -t 1 ]] && echo "+ kubectl $@"; command kubectl $@; }
 ```
 
 ### Syntax explanation

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ and save it in your $HOME directory, then edit your .bashrc/.zshrc file with:
 `.zshrc` file:
 
 ```sh
-function kubectl() { [[ -t 1 ]] && echo "+ kubectl $@"; command kubectl $@; }
+function kubectl() { echo "+ kubectl $@">&2; command kubectl $@; }
 ```
 
 ### Syntax explanation


### PR DESCRIPTION
I've updated "Print the full command before running it" function to avoid errors on command piping

Example:

```bash
kubectl -n default create secret generic credentials --from-file=/tmp/credentials.json --dry-run -o yaml | kubectl apply -f -
```

Throws error:

```
error: error parsing STDIN: error converting YAML to JSON: yaml: line 2: mapping values are not allowed in this context
```

Because `+kubectl -n default create secret generic...` included onto the pipe, but should not
